### PR TITLE
Fix global replacement of noscript

### DIFF
--- a/background/content.js
+++ b/background/content.js
@@ -4,6 +4,6 @@
   var tags = document.getElementsByTagName('noscript');
 
   for (var i = 0; i < tags.length; i++) {
-    tags[i].outerHTML = tags[i].outerHTML.replace(/noscript/g, 'div');
+    tags[i].outerHTML = tags[i].outerHTML.replace(/noscript/, 'div');
   }
 })();


### PR DESCRIPTION
every occurence of `noscript` was replaced by `div` in the whole HTML
of every `<noscript>` HTML element, breaking code/URL or replacing text
where noscript is used.
This patch fixes it by only replacing the first occurence of `noscript`,
i.e. the tag name.