### PR TITLE
Git ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore created XPI packages.
 disable-javascript@pacassi.ch.xpi
+
+node_modules


### PR DESCRIPTION
I noticed when I did `npm install`, `git` said "hey! what about these node_nodules??", so I thought I should tell it what I think about that. :)

In all seriousness for anyone who looks at this and wonders why,
- node_modules should not be committed, because:
- node_modules is massive, and
- each developer should fetch it from npm using `npm install`, since
- each module required is specified in the package.json (and optionally other lockfiles).